### PR TITLE
Add steal, guest and guest_nice for cpu stat

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+= 0.2.2 - 5-Mar-2019
+* Added the steal, guest and guest_nice attributes for cpu stats.
+
 = 0.2.1 - 25-Jan-2019
 * Fixed license name (missing hyphen).
 * Added metadata to the gemspec.

--- a/lib/linux/kstat.rb
+++ b/lib/linux/kstat.rb
@@ -7,7 +7,7 @@ module Linux
     extend Forwardable
 
     # The version of the linux-kstat library
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
 
     # :stopdoc:
 
@@ -26,13 +26,16 @@ module Linux
     #   kstat = Linux::Kstat.new
     #
     #   kstat[:cpu] => {
-    #     :idle     => 250713454,
-    #     :iowait   => 2745691,
-    #     :irq      => 39717,
-    #     :softirq  => 31323,
-    #     :system   => 1881655,
-    #     :nice     => 117158,
-    #     :user     => 7137418
+    #     :idle       => 250713454,
+    #     :iowait     => 2745691,
+    #     :irq        => 39717,
+    #     :softirq    => 31323,
+    #     :system     => 1881655,
+    #     :nice       => 117158,
+    #     :user       => 7137418,
+    #     :steal      => 0,
+    #     :guest      => 1162987977,
+    #     :guest_nice => 0
     #   }
     #
     #   kstat[:processes] # => 1299560
@@ -54,13 +57,16 @@ module Linux
         unless info.empty?
           if info.first =~ /^cpu/i
             hash[info.first.to_sym] = {
-              :user    => info[1].to_i,
-              :nice    => info[2].to_i,
-              :system  => info[3].to_i,
-              :idle    => info[4].to_i,
-              :iowait  => info[5].to_i,
-              :irq     => info[6].to_i,
-              :softirq => info[7].to_i
+              :user       => info[1].to_i,
+              :nice       => info[2].to_i,
+              :system     => info[3].to_i,
+              :idle       => info[4].to_i,
+              :iowait     => info[5].to_i,
+              :irq        => info[6].to_i,
+              :softirq    => info[7].to_i,
+              :steal      => info[8].to_i,
+              :guest      => info[9].to_i,
+              :guest_nice => info[10].to_i
             }
           else
             if info.size > 2

--- a/linux-kstat.gemspec
+++ b/linux-kstat.gemspec
@@ -3,7 +3,7 @@ require 'rbconfig'
 
 Gem::Specification.new do |gem|
   gem.name       = 'linux-kstat'
-  gem.version    = '0.2.1'
+  gem.version    = '0.2.2'
   gem.license    = 'Apache-2.0'
   gem.author     = 'Daniel J. Berger'
   gem.email      = 'djberg96@gmail.com'

--- a/spec/linux_kstat_spec.rb
+++ b/spec/linux_kstat_spec.rb
@@ -11,7 +11,7 @@ describe Linux::Kstat do
 
   context "constants" do
     it "defines a version constant that is set to the expected value" do
-      expect(Linux::Kstat::VERSION).to eql('0.2.1')
+      expect(Linux::Kstat::VERSION).to eql('0.2.2')
       expect(Linux::Kstat::VERSION.frozen?).to be(true)
     end
   end
@@ -20,6 +20,7 @@ describe Linux::Kstat do
     it "allows hash style key access" do
       expect(subject).to respond_to(:[])
       expect{ subject[:cpu] }.to_not raise_error
+      expect(subject[:cpu].keys.size).to eql(10)
     end
 
     it "contains the expected keys and value types" do


### PR DESCRIPTION
Add the steal, guest and guest_nice columns, which were added in Linux 2.6.11 or later.