### PR TITLE
Add local rubocop.yml file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,50 @@
+require: rubocop-rspec
+
+RSpec/MultipleExpectations:
+  Max: 4
+RSpec/ContextWording:
+  Enabled: false
+RSpec/FilePath:
+  SpecSuffixOnly: true
+RSpec/InstanceVariable:
+  Enabled: false
+
+AllCops:
+  NewCops: enable
+Lint/AssignmentInCondition:
+  Enabled: false
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/CaseIndentation:
+  IndentOneStep: true
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  IgnoredMethods: ['describe', 'context']
+Metrics/ClassLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - 'lib/linux-kstat.rb'

--- a/spec/linux_kstat_spec.rb
+++ b/spec/linux_kstat_spec.rb
@@ -11,27 +11,27 @@ require 'linux/kstat'
 describe Linux::Kstat do
   let(:kstat){ described_class.new }
 
-  context "constants" do
-    it "defines a version constant that is set to the expected value" do
+  context 'constants' do
+    it 'defines a version constant that is set to the expected value' do
       expect(Linux::Kstat::VERSION).to eql('0.2.6')
       expect(Linux::Kstat::VERSION).to be_frozen
     end
   end
 
-  context "hash access" do
-    it "allows hash style key access" do
+  context 'hash access' do
+    it 'allows hash style key access' do
       expect(kstat).to respond_to(:[])
       expect{ kstat[:cpu] }.not_to raise_error
       expect(kstat[:cpu].keys.size).to be(10)
     end
 
-    it "contains the expected keys and value types" do
+    it 'contains the expected keys and value types' do
       expect(kstat[:cpu]).to be_kind_of(Hash)
       expect(kstat[:btime]).to be_kind_of(Numeric)
       expect(kstat[:intr]).to be_kind_of(Array)
     end
 
-    it "does not allow key assignment" do
+    it 'does not allow key assignment' do
       expect{ kstat[:cpu] = 'test' }.to raise_error(NoMethodError)
     end
   end


### PR DESCRIPTION
This adds a project-specific .rubocop.yml file. I also updated the specs slightly (just quotes).