### PR TITLE
Rubocop updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Layout/SpaceBeforeBlockBraces:
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
-  IgnoredMethods: ['describe', 'context']
+  AllowedMethods: ['describe', 'context']
 Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ RSpec/FilePath:
   SpecSuffixOnly: true
 RSpec/InstanceVariable:
   Enabled: false
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/linux_kstat_spec.rb'
 
 AllCops:
   NewCops: enable
@@ -28,6 +31,8 @@ Style/ConditionalAssignment:
 Style/GuardClause:
   Enabled: false
 Style/HashSyntax:
+  Enabled: false
+Style/SlicingWithRange:
   Enabled: false
 Layout/EmptyLineAfterGuardClause:
   Enabled: false

--- a/spec/linux_kstat_spec.rb
+++ b/spec/linux_kstat_spec.rb
@@ -26,9 +26,9 @@ describe Linux::Kstat do
     end
 
     it 'contains the expected keys and value types' do
-      expect(kstat[:cpu]).to be_kind_of(Hash)
-      expect(kstat[:btime]).to be_kind_of(Numeric)
-      expect(kstat[:intr]).to be_kind_of(Array)
+      expect(kstat[:cpu]).to be_a(Hash)
+      expect(kstat[:btime]).to be_a(Numeric)
+      expect(kstat[:intr]).to be_a(Array)
     end
 
     it 'does not allow key assignment' do


### PR DESCRIPTION
Just some minor rubocop updates. While I was here I removed Ruby 2.6 from the test matrix, it's ancient at this point.