### PR TITLE
Minor optimizations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.2.8 - 13-Jun-2025
 * Minor optimization where I avoid making repeated calls.
+* Add a keys method delegator.
 
 ## 0.2.7 - 20-Apr-2024
 * Rubocop updates.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.2.8 - 13-Jun-2025
+* Minor optimization where I avoid making repeated calls.
+
 ## 0.2.7 - 20-Apr-2024
 * Rubocop updates.
 * Spec updates.

--- a/lib/linux/kstat.rb
+++ b/lib/linux/kstat.rb
@@ -16,6 +16,7 @@ module Linux
     # Delegate the the [] and inspect methods to the @hash variable
     def_delegator(:@hash, :[])
     def_delegator(:@hash, :inspect)
+    def_delegator(:@hash, :keys)
 
     # :startdoc:
 

--- a/lib/linux/kstat.rb
+++ b/lib/linux/kstat.rb
@@ -9,7 +9,7 @@ module Linux
     extend Forwardable
 
     # The version of the linux-kstat library
-    VERSION = '0.2.7'
+    VERSION = '0.2.8'
 
     # :stopdoc:
 
@@ -56,9 +56,12 @@ module Linux
 
       File.readlines('/proc/stat').each do |line|
         info = line.split
+        next if info.empty?
+        key = info.first.to_sym
+
         unless info.empty?
           if info.first =~ /^cpu/i
-            hash[info.first.to_sym] = {
+            hash[key] = {
               :user => info[1].to_i,
               :nice => info[2].to_i,
               :system => info[3].to_i,
@@ -71,9 +74,9 @@ module Linux
               :guest_nice => info[10].to_i
             }
           elsif info.size > 2
-            hash[info.first.to_sym] = info[1..-1].map(&:to_i)
+            hash[key] = info[1..-1].map(&:to_i)
           else
-            hash[info.first.to_sym] = info[1].to_i
+            hash[key] = info[1].to_i
           end
         end
       end

--- a/linux-kstat.gemspec
+++ b/linux-kstat.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |gem|
   gem.name       = 'linux-kstat'
-  gem.version    = '0.2.7'
+  gem.version    = '0.2.8'
   gem.license    = 'Apache-2.0'
   gem.author     = 'Daniel J. Berger'
   gem.email      = 'djberg96@gmail.com'

--- a/spec/linux_kstat_spec.rb
+++ b/spec/linux_kstat_spec.rb
@@ -31,6 +31,12 @@ describe Linux::Kstat do
       expect(kstat[:intr]).to be_a(Array)
     end
 
+    it 'delegates the keys method' do
+      expect(kstat).to respond_to(:keys)
+      expect(kstat.keys).to be_a(Array)
+      expect(kstat.keys).to include(:cpu)
+    end
+
     it 'does not allow key assignment' do
       expect{ kstat[:cpu] = 'test' }.to raise_error(NoMethodError)
     end

--- a/spec/linux_kstat_spec.rb
+++ b/spec/linux_kstat_spec.rb
@@ -13,7 +13,7 @@ describe Linux::Kstat do
 
   context 'constants' do
     it 'defines a version constant that is set to the expected value' do
-      expect(Linux::Kstat::VERSION).to eql('0.2.7')
+      expect(Linux::Kstat::VERSION).to eql('0.2.8')
       expect(Linux::Kstat::VERSION).to be_frozen
     end
   end


### PR DESCRIPTION
Avoid multiple calls to `info.first.to_sym`. I also added a `keys` delegator for convenience.